### PR TITLE
修复Request Header Fields Too Large

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,13 @@ app.use('/', createProxyMiddleware({
   target: 'https://api.openai.com',
   changeOrigin: true,
   onProxyReq: (proxyReq, req, res) => {
+    const headers = Object.keys(proxyReq.getHeaders());
+    headers.forEach(header => {
+      if (header.startsWith('x-fc')) {
+        // 移除以'x-fc'开头的请求头(x-fc开头请求头是云函数给加上的，OpenAI接口对请求头size做了限制，不删的话会报错)
+        proxyReq.removeHeader(header);
+      }
+    });
     // 移除 'x-forwarded-for' 和 'x-real-ip' 头，以确保不传递原始客户端 IP 地址等信息
     proxyReq.removeHeader('x-forwarded-for');
     proxyReq.removeHeader('x-real-ip');


### PR DESCRIPTION
删除了FC云函数加上的请求头，解决了Request Header Fields Too Large的问题